### PR TITLE
Bugfix clean endpoints

### DIFF
--- a/src/main/java/com/example/demo/domain/authority/AuthorityController.java
+++ b/src/main/java/com/example/demo/domain/authority/AuthorityController.java
@@ -27,7 +27,7 @@ public class AuthorityController {
     try {
       return new ResponseEntity<>(authorityService.save(new Authority(null, name)), HttpStatus.CREATED);
     } catch (InstanceAlreadyExistsException e) {
-      return new ResponseEntity<>("authority already exists", HttpStatus.CONFLICT);
+      return new ResponseEntity<>("authority \"" + name + "\" already exists", HttpStatus.CONFLICT);
     }
   }
 
@@ -65,7 +65,7 @@ public class AuthorityController {
     } catch (InstanceNotFoundException e) {
       return authorityNotFound;
     } catch (InstanceAlreadyExistsException e) {
-      return new ResponseEntity<>("authority with this name already exists", HttpStatus.CONFLICT);
+      return new ResponseEntity<>("authority \"" + newName + "\" already exists", HttpStatus.CONFLICT);
     }
   }
 

--- a/src/main/java/com/example/demo/domain/authority/AuthorityRepository.java
+++ b/src/main/java/com/example/demo/domain/authority/AuthorityRepository.java
@@ -14,7 +14,7 @@ public interface AuthorityRepository extends JpaRepository<Authority, UUID> {
     Authority findByName(String name);
 
     @Transactional
-    @Modifying
+    @Modifying(clearAutomatically=true, flushAutomatically = true)
     @Query("update Authority a set a.name = ?2 where a.name = ?1")
     void updateNameByName(String name, String newName);
 


### PR DESCRIPTION
- fixed dirty read by UserRepository.updateNameByName()
- made error message returned on InstanceAlreadyExists a bit more user friendly