### PR TITLE
bugfix addRoleById

### DIFF
--- a/src/main/java/com/example/demo/domain/user/UserServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/user/UserServiceImpl.java
@@ -63,15 +63,16 @@ public class UserServiceImpl implements UserService, UserDetailsService {
 
     @Override
     public User addRoleById(UUID uuid, UUID roleId) throws InstanceNotFoundException {
+        User user = findById(uuid);
         if (!roleRepository.existsById(roleId)) {
             throw new InstanceNotFoundException("Role not found");
         }
-        if (roleRepository.findById(roleId).isEmpty()) {
+        Optional<Role> optionalRole = roleRepository.findById(roleId);
+        if (optionalRole.isEmpty()) {
             throw new NoSuchElementException("Role is null");
         }
-        User user = findById(uuid);
         Set<Role> roles = user.getRoles();
-        roles.add(roleRepository.findById(roleId).get());
+        roles.add(optionalRole.get());
         return user;
     }
 


### PR DESCRIPTION
if neither user UUID nor role UUID are valid, the exception message will now prioritize the user instead of the role